### PR TITLE
ci(security): disable yarn lifecycle scripts (YARN_ENABLE_SCRIPTS=false)

### DIFF
--- a/.github/actions/init-node/action.yml
+++ b/.github/actions/init-node/action.yml
@@ -38,6 +38,8 @@ runs:
         key: cache-build-results-${{ runner.os }}-${{ github.sha }}
 
     - name: install [root] dependencies
+      env:
+        YARN_ENABLE_SCRIPTS: 'false'
       run: yarn --immutable
       shell: bash
 
@@ -48,30 +50,42 @@ runs:
     # The directories under the example directory do not consider the strictness of yarn.lock
     - name: install [examples/enclosure-vue3] dependencies
       working-directory: ./examples/enclosure-vue3
+      env:
+        YARN_ENABLE_SCRIPTS: 'false'
       run: yarn --immutable
       shell: bash
 
     - name: install [examples/enclosure-vue2.7] dependencies
       working-directory: ./examples/enclosure-vue2.7
+      env:
+        YARN_ENABLE_SCRIPTS: 'false'
       run: yarn --immutable
       shell: bash
 
     - name: install [examples/enclosure-vue2] dependencies
       working-directory: ./examples/enclosure-vue2
+      env:
+        YARN_ENABLE_SCRIPTS: 'false'
       run: yarn --immutable
       shell: bash
 
     - name: install [examples/insider-vue3] dependencies
       working-directory: ./examples/insider-vue3
+      env:
+        YARN_ENABLE_SCRIPTS: 'false'
       run: yarn --immutable
       shell: bash
 
     - name: install [examples/insider-vue2.7] dependencies
       working-directory: ./examples/insider-vue2.7
+      env:
+        YARN_ENABLE_SCRIPTS: 'false'
       run: yarn --immutable
       shell: bash
 
     - name: install [examples/insider-vue2] dependencies
       working-directory: ./examples/insider-vue2
+      env:
+        YARN_ENABLE_SCRIPTS: 'false'
       run: yarn --immutable
       shell: bash


### PR DESCRIPTION
## 背景

npm エコシステムのサプライチェーン攻撃 (Mini Shai-Hulud 2nd 等) が継続しており、
CI runner 上で侵害版パッケージの `postinstall` / `preinstall` lifecycle script が実行されると、
GITHUB_TOKEN や npm token など各種 secret が外部に流出するリスクがある。

yarn berry には `--ignore-scripts` フラグが無いため、環境変数
`YARN_ENABLE_SCRIPTS=false` で同等の挙動になる。

## 変更

`.github/actions/init-node/action.yml` の **全 7 箇所の install step** に
`env: YARN_ENABLE_SCRIPTS: 'false'` を追加 (root + examples/* 6 個)。

```diff
  - name: install [root] dependencies
+   env:
+     YARN_ENABLE_SCRIPTS: 'false'
    run: yarn --immutable
    shell: bash

  - name: install [examples/enclosure-vue3] dependencies
    working-directory: ./examples/enclosure-vue3
+   env:
+     YARN_ENABLE_SCRIPTS: 'false'
    run: yarn --immutable
    shell: bash
  ... (他 5 個も同様)
```

## 想定される影響

- `postinstall` で native build が必要な依存がある場合、CI が失敗する可能性
- 落ちた場合は yarn の `unplugged` 設定で個別 allow か、必要なら本 PR を revert

## 参考

- https://blog.flatt.tech/entry/mini_shai_hulud_2nd

🤖 Generated with [Claude Code](https://claude.com/claude-code)