### PR TITLE
chore(security): disable yarn lifecycle scripts (enableScripts: false)

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -2,6 +2,8 @@ compressionLevel: mixed
 
 enableGlobalCache: false
 
+enableScripts: false
+
 nodeLinker: node-modules
 
 npmAuthToken: "${NODE_AUTH_TOKEN:-''}"

--- a/examples/enclosure-vue2.7/.yarnrc.yml
+++ b/examples/enclosure-vue2.7/.yarnrc.yml
@@ -2,6 +2,8 @@ compressionLevel: mixed
 
 enableGlobalCache: false
 
+enableScripts: false
+
 nodeLinker: node-modules
 
 yarnPath: ../../.yarn/releases/yarn-4.0.0.cjs

--- a/examples/enclosure-vue2/.yarnrc.yml
+++ b/examples/enclosure-vue2/.yarnrc.yml
@@ -2,6 +2,8 @@ compressionLevel: mixed
 
 enableGlobalCache: false
 
+enableScripts: false
+
 nodeLinker: node-modules
 
 yarnPath: ../../.yarn/releases/yarn-4.0.0.cjs

--- a/examples/enclosure-vue3/.yarnrc.yml
+++ b/examples/enclosure-vue3/.yarnrc.yml
@@ -2,6 +2,8 @@ compressionLevel: mixed
 
 enableGlobalCache: false
 
+enableScripts: false
+
 nodeLinker: node-modules
 
 yarnPath: ../../.yarn/releases/yarn-4.0.0.cjs

--- a/examples/insider-vue2.7/.yarnrc.yml
+++ b/examples/insider-vue2.7/.yarnrc.yml
@@ -2,6 +2,8 @@ compressionLevel: mixed
 
 enableGlobalCache: false
 
+enableScripts: false
+
 nodeLinker: node-modules
 
 yarnPath: ../../.yarn/releases/yarn-4.0.0.cjs

--- a/examples/insider-vue2/.yarnrc.yml
+++ b/examples/insider-vue2/.yarnrc.yml
@@ -2,6 +2,8 @@ compressionLevel: mixed
 
 enableGlobalCache: false
 
+enableScripts: false
+
 nodeLinker: node-modules
 
 yarnPath: ../../.yarn/releases/yarn-4.0.0.cjs

--- a/examples/insider-vue3/.yarnrc.yml
+++ b/examples/insider-vue3/.yarnrc.yml
@@ -2,6 +2,8 @@ compressionLevel: mixed
 
 enableGlobalCache: false
 
+enableScripts: false
+
 nodeLinker: node-modules
 
 yarnPath: ../../.yarn/releases/yarn-4.0.0.cjs


### PR DESCRIPTION
## 背景

npm エコシステムのサプライチェーン攻撃 (Mini Shai-Hulud 2nd 等) 対策として、
ローカル/CI 双方の install 時に postinstall lifecycle を抑止する。

yarn berry は `.npmrc` の `ignore-scripts` ではなく `.yarnrc.yml` の `enableScripts: false`
で同等の挙動になる。

## 変更

monorepo 構成のため、root + examples/* 計 7 個の `.yarnrc.yml` すべてに `enableScripts: false` を追加。

- `.yarnrc.yml`
- `examples/enclosure-vue2.7/.yarnrc.yml`
- `examples/enclosure-vue2/.yarnrc.yml`
- `examples/enclosure-vue3/.yarnrc.yml`
- `examples/insider-vue2.7/.yarnrc.yml`
- `examples/insider-vue2/.yarnrc.yml`
- `examples/insider-vue3/.yarnrc.yml`

## なぜ `npmMinimalAgeGate` を入れないか

リリース直後の未審査バージョンを拒否する `npmMinimalAgeGate` は **yarn 4.12+** で
正式利用可能。本リポジトリは yarn 4.0.0 のため、yarn 上げと合わせて別 PR で対応する。

## 想定される影響

- 初回 install 後に native build が必要な依存がある場合、CI が失敗する可能性
- 落ちた場合は yarn の `unplugged` 設定で個別 allow か、必要なら本 PR を revert

## 参考

- https://blog.flatt.tech/entry/mini_shai_hulud_2nd

🤖 Generated with [Claude Code](https://claude.com/claude-code)